### PR TITLE
Fixar formatador de arquivo adicionando cache

### DIFF
--- a/gulp/tasks/formatter.js
+++ b/gulp/tasks/formatter.js
@@ -1,8 +1,8 @@
 module.exports = function (gulp, options, plugins) {
-  gulp.task('formatter', function() {
+  gulp.task('formatter:js', function() {
     return gulp.src(options.devPaths.allFiles)
       .pipe(
-        plugins.cached('formatted')
+        plugins.cached('scripts')
       )
       .pipe(plugins.jsbeautifier({
         indent_level: 4,

--- a/gulp/tasks/formatter.js
+++ b/gulp/tasks/formatter.js
@@ -1,6 +1,9 @@
 module.exports = function (gulp, options, plugins) {
   gulp.task('formatter', function() {
     return gulp.src(options.devPaths.allFiles)
+      .pipe(
+        plugins.cached('formatted')
+      )
       .pipe(plugins.jsbeautifier({
         indent_level: 4,
         js: {

--- a/gulp/tasks/main.js
+++ b/gulp/tasks/main.js
@@ -9,10 +9,10 @@ module.exports = function (gulp, options, plugins) {
         'images', 
         'fonts'
       ], 
-      'formatter',
       'templates', 
       'index', 
       'reload', 
+      'formatter:js',
       cb
     );
   });

--- a/gulp/tasks/main.js
+++ b/gulp/tasks/main.js
@@ -4,12 +4,12 @@ module.exports = function (gulp, options, plugins) {
   gulp.task('compile', function(cb) {
     runSequence(
       [
-        'formatter',
         'scripts', 
         'styles', 
         'images', 
         'fonts'
       ], 
+      'formatter',
       'templates', 
       'index', 
       'reload', 

--- a/src/app/views/home/test/homeTestTemplate.html
+++ b/src/app/views/home/test/homeTestTemplate.html
@@ -1,1 +1,1 @@
-<h1>Home Template Test 2</h1>
+<h1>Home Template Test</h1>

--- a/src/app/views/home/test/homeTestTemplate.html
+++ b/src/app/views/home/test/homeTestTemplate.html
@@ -1,1 +1,1 @@
-<h1>Home Template Test</h1>
+<h1>Home Template Test 2</h1>


### PR DESCRIPTION
Estava com um problema no livereload porque não tinha colocado cache de arquivos para o formatter.
Além disso, a task estava sendo chamada no lugar errado.