### PR TITLE
Force angular to 1.5.x

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -11,7 +11,7 @@
     "tests"
   ],
   "dependencies": {
-    "angular": "latest",
+    "angular": "~1.5.11",
     "angular-mocks": "latest",
     "angular-resource": "latest",
     "angular-local-storage": "latest",


### PR DESCRIPTION
For some reason, angular 1.6.x is not working with Bolt. I will fix it later.