### PR TITLE
Fixing ui-router dependency

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -11,12 +11,11 @@
     "tests"
   ],
   "dependencies": {
-    "angular": "~1.5.11",
+    "angular": "latest",
     "angular-mocks": "latest",
     "angular-resource": "latest",
     "angular-local-storage": "latest",
-    "ui-router": "latest",
-    "ui-router-extras": "latest",
+    "angular-ui-router": "latest",
     "lodash": "latest",
     "ngDialog": "latest"
   }


### PR DESCRIPTION
In the previously pull request(https://github.com/DomPhysis/bolt/pull/14) @marcelinhov2 pushed AngularJS v1.5.11 because of an error with `ui-router` dependency.

I checked the dependencies and realized that the right package is `angular-ui-router` as it is in their main repo (https://github.com/angular-ui/ui-router/blob/master/bower.json). So, fixing it, bower resolves project's dependencies to Angular v1.6.1 and ui-router v0.4.2, which are now compatible.

I tested it out, and now it is back working with the latest versions.